### PR TITLE
Fix `root` when not started using `npm start`

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -24,9 +24,8 @@ class Core {
 		this.pluginManager = new PluginManager();
 	}
 
-	// TODO: Root will be inaccurate if ijo is not started using npm start.
 	get root() {
-		return process.cwd();
+		return path.dirname(require.main.filename);
 	}
 	
 	/**

--- a/src/core.js
+++ b/src/core.js
@@ -25,7 +25,7 @@ class Core {
 	}
 
 	get root() {
-		return path.dirname(require.main.filename);
+		return path.join(path.dirname(require.main.filename), "../");
 	}
 	
 	/**


### PR DESCRIPTION
Just a quick fix for the `root` getter that allows it to work when not using `npm start`. 